### PR TITLE
ci: pass private registry credentials explicitly

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -12,4 +12,7 @@ on:
 jobs:
   lint-and-test:
     uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@main
-    secrets: inherit
+    with:
+      registry-auth-required: true
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -13,8 +13,13 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   quality-checks:
     uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@main
-    secrets: inherit
+    with:
+      registry-auth-required: true
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   release-packages:
     needs: [quality-checks]
     uses: otedesco/gh-action-templates/.github/workflows/release-package.yml@main
-    secrets: inherit
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## Summary
- replace inherited workflow secrets with explicit NPM_TOKEN/GH_TOKEN mappings
- require registry authentication for quality and package workflows

## Validation
- central registry-auth contract validates the explicit Notify secret wiring