### PR TITLE
ci: pin immutable workflow references (OPS-182)

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   lint-and-test:
-    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@46eefa62da65e573739f4ac686560cd14bb7849b # central quality workflow release 2026-09-02
+    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@b0bd33051b7b5b8ebe0a8f5a1c588ea0d466ed2d # central quality workflow release 2026-09-02
     with:
       registry-auth-required: true
     secrets:

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   lint-and-test:
-    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@main
+    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@46eefa62da65e573739f4ac686560cd14bb7849b # central quality workflow release 2026-09-02
     with:
       registry-auth-required: true
     secrets:

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -12,14 +12,14 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   quality-checks:
-    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@main
+    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@46eefa62da65e573739f4ac686560cd14bb7849b # central quality workflow release 2026-09-02
     with:
       registry-auth-required: true
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   release-packages:
     needs: [quality-checks]
-    uses: otedesco/gh-action-templates/.github/workflows/release-package.yml@main
+    uses: otedesco/gh-action-templates/.github/workflows/release-package.yml@46eefa62da65e573739f4ac686560cd14bb7849b # central quality workflow release 2026-09-02
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -12,14 +12,14 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   quality-checks:
-    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@46eefa62da65e573739f4ac686560cd14bb7849b # central quality workflow release 2026-09-02
+    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@b0bd33051b7b5b8ebe0a8f5a1c588ea0d466ed2d # central quality workflow release 2026-09-02
     with:
       registry-auth-required: true
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   release-packages:
     needs: [quality-checks]
-    uses: otedesco/gh-action-templates/.github/workflows/release-package.yml@46eefa62da65e573739f4ac686560cd14bb7849b # central quality workflow release 2026-09-02
+    uses: otedesco/gh-action-templates/.github/workflows/release-package.yml@b0bd33051b7b5b8ebe0a8f5a1c588ea0d466ed2d # central quality workflow release 2026-09-02
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
OPS-182 only: pin quality and package-release reusable workflow calls to central release `b0bd33051b7b5b8ebe0a8f5a1c588ea0d466ed2d`.

Based on origin/main; excludes OPS-183 permission changes.