### PR TITLE
ci: pin shared workflows by commit (OPS-182)

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   lint-and-test:
-    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@93379e36e551d3642c961a25b724a61c15b14421 # central coverage report compatibility release 2026-09-03
+    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@c634d37a48f18d3640f55e376fc7adff2807e4e6 # central coverage report compatibility release 2026-09-03
     with:
       registry-auth-required: true
     secrets:

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   lint-and-test:
-    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@b31a412a635636c20e9e026bd85e345880a5c3a5 # OPS-182 consumer compatibility fix
+    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@0a9c7f317a2e922aed37b526918fa16d51b8041e # OPS-182 consumer compatibility fix
     with:
       registry-auth-required: true
     secrets:

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   lint-and-test:
-    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@0a9c7f317a2e922aed37b526918fa16d51b8041e # OPS-182 consumer compatibility fix
+    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@9282fc2387d782afa7d461afbd51c89a1918abdb # OPS-182 consumer compatibility fix
     with:
       registry-auth-required: true
     secrets:

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   lint-and-test:
-    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@5024403d1e4eaf9a26603fb71773a5260ea5f370 # central coverage report compatibility release 2026-09-03
+    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@b31a412a635636c20e9e026bd85e345880a5c3a5 # OPS-182 consumer compatibility fix
     with:
       registry-auth-required: true
     secrets:

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   lint-and-test:
-    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@c634d37a48f18d3640f55e376fc7adff2807e4e6 # central coverage report compatibility release 2026-09-03
+    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@5024403d1e4eaf9a26603fb71773a5260ea5f370 # central coverage report compatibility release 2026-09-03
     with:
       registry-auth-required: true
     secrets:

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   lint-and-test:
-    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@b0bd33051b7b5b8ebe0a8f5a1c588ea0d466ed2d # central quality workflow release 2026-09-02
+    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@dc35994d4f78f96059e0a13008e04d12c2ad51f9 # central coverage gate release 2026-09-02
     with:
       registry-auth-required: true
     secrets:

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   lint-and-test:
-    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@main
+    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@b0bd33051b7b5b8ebe0a8f5a1c588ea0d466ed2d # central quality workflow release 2026-09-02
     with:
       registry-auth-required: true
     secrets:

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   lint-and-test:
-    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@dc35994d4f78f96059e0a13008e04d12c2ad51f9 # central coverage gate release 2026-09-02
+    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@93379e36e551d3642c961a25b724a61c15b14421 # central coverage report compatibility release 2026-09-03
     with:
       registry-auth-required: true
     secrets:

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -12,14 +12,14 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   quality-checks:
-    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@dc35994d4f78f96059e0a13008e04d12c2ad51f9 # central coverage gate release 2026-09-02
+    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@93379e36e551d3642c961a25b724a61c15b14421 # central coverage report compatibility release 2026-09-03
     with:
       registry-auth-required: true
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   release-packages:
     needs: [quality-checks]
-    uses: otedesco/gh-action-templates/.github/workflows/release-package.yml@dc35994d4f78f96059e0a13008e04d12c2ad51f9 # central coverage gate release 2026-09-02
+    uses: otedesco/gh-action-templates/.github/workflows/release-package.yml@93379e36e551d3642c961a25b724a61c15b14421 # central coverage report compatibility release 2026-09-03
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -12,14 +12,14 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   quality-checks:
-    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@0a9c7f317a2e922aed37b526918fa16d51b8041e # OPS-182 consumer compatibility fix
+    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@9282fc2387d782afa7d461afbd51c89a1918abdb # OPS-182 consumer compatibility fix
     with:
       registry-auth-required: true
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   release-packages:
     needs: [quality-checks]
-    uses: otedesco/gh-action-templates/.github/workflows/release-package.yml@0a9c7f317a2e922aed37b526918fa16d51b8041e # OPS-182 consumer compatibility fix
+    uses: otedesco/gh-action-templates/.github/workflows/release-package.yml@9282fc2387d782afa7d461afbd51c89a1918abdb # OPS-182 consumer compatibility fix
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -12,14 +12,14 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   quality-checks:
-    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@main
+    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@b0bd33051b7b5b8ebe0a8f5a1c588ea0d466ed2d # central quality workflow release 2026-09-02
     with:
       registry-auth-required: true
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   release-packages:
     needs: [quality-checks]
-    uses: otedesco/gh-action-templates/.github/workflows/release-package.yml@main
+    uses: otedesco/gh-action-templates/.github/workflows/release-package.yml@b0bd33051b7b5b8ebe0a8f5a1c588ea0d466ed2d # central quality workflow release 2026-09-02
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -12,14 +12,14 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   quality-checks:
-    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@b31a412a635636c20e9e026bd85e345880a5c3a5 # OPS-182 consumer compatibility fix
+    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@0a9c7f317a2e922aed37b526918fa16d51b8041e # OPS-182 consumer compatibility fix
     with:
       registry-auth-required: true
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   release-packages:
     needs: [quality-checks]
-    uses: otedesco/gh-action-templates/.github/workflows/release-package.yml@b31a412a635636c20e9e026bd85e345880a5c3a5 # OPS-182 consumer compatibility fix
+    uses: otedesco/gh-action-templates/.github/workflows/release-package.yml@0a9c7f317a2e922aed37b526918fa16d51b8041e # OPS-182 consumer compatibility fix
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -12,14 +12,14 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   quality-checks:
-    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@5024403d1e4eaf9a26603fb71773a5260ea5f370 # central coverage report compatibility release 2026-09-03
+    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@b31a412a635636c20e9e026bd85e345880a5c3a5 # OPS-182 consumer compatibility fix
     with:
       registry-auth-required: true
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   release-packages:
     needs: [quality-checks]
-    uses: otedesco/gh-action-templates/.github/workflows/release-package.yml@5024403d1e4eaf9a26603fb71773a5260ea5f370 # central coverage report compatibility release 2026-09-03
+    uses: otedesco/gh-action-templates/.github/workflows/release-package.yml@b31a412a635636c20e9e026bd85e345880a5c3a5 # OPS-182 consumer compatibility fix
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -12,14 +12,14 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   quality-checks:
-    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@c634d37a48f18d3640f55e376fc7adff2807e4e6 # central coverage report compatibility release 2026-09-03
+    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@5024403d1e4eaf9a26603fb71773a5260ea5f370 # central coverage report compatibility release 2026-09-03
     with:
       registry-auth-required: true
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   release-packages:
     needs: [quality-checks]
-    uses: otedesco/gh-action-templates/.github/workflows/release-package.yml@c634d37a48f18d3640f55e376fc7adff2807e4e6 # central coverage report compatibility release 2026-09-03
+    uses: otedesco/gh-action-templates/.github/workflows/release-package.yml@5024403d1e4eaf9a26603fb71773a5260ea5f370 # central coverage report compatibility release 2026-09-03
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -12,14 +12,14 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   quality-checks:
-    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@b0bd33051b7b5b8ebe0a8f5a1c588ea0d466ed2d # central quality workflow release 2026-09-02
+    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@dc35994d4f78f96059e0a13008e04d12c2ad51f9 # central coverage gate release 2026-09-02
     with:
       registry-auth-required: true
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   release-packages:
     needs: [quality-checks]
-    uses: otedesco/gh-action-templates/.github/workflows/release-package.yml@b0bd33051b7b5b8ebe0a8f5a1c588ea0d466ed2d # central quality workflow release 2026-09-02
+    uses: otedesco/gh-action-templates/.github/workflows/release-package.yml@dc35994d4f78f96059e0a13008e04d12c2ad51f9 # central coverage gate release 2026-09-02
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -12,14 +12,14 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   quality-checks:
-    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@93379e36e551d3642c961a25b724a61c15b14421 # central coverage report compatibility release 2026-09-03
+    uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@c634d37a48f18d3640f55e376fc7adff2807e4e6 # central coverage report compatibility release 2026-09-03
     with:
       registry-auth-required: true
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   release-packages:
     needs: [quality-checks]
-    uses: otedesco/gh-action-templates/.github/workflows/release-package.yml@93379e36e551d3642c961a25b724a61c15b14421 # central coverage report compatibility release 2026-09-03
+    uses: otedesco/gh-action-templates/.github/workflows/release-package.yml@c634d37a48f18d3640f55e376fc7adff2807e4e6 # central coverage report compatibility release 2026-09-03
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/coverage-baselines/current.json
+++ b/coverage-baselines/current.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": 1,
+  "repository": "notify",
+  "commit": "f1ae9dbf964ef143fa812b8f6ce311742cba71f8",
+  "timestamp": "2026-09-03T00:00:00Z",
+  "metrics": {
+    "statements": { "covered": 4, "total": 1053, "percent": 0.3798670465337132 },
+    "branches": { "covered": 1, "total": 18, "percent": 5.555555555555555 },
+    "functions": { "covered": 0, "total": 17, "percent": 0 },
+    "lines": { "covered": 4, "total": 1053, "percent": 0.3798670465337132 }
+  }
+}

--- a/coverage-baselines/current.json
+++ b/coverage-baselines/current.json
@@ -4,7 +4,11 @@
   "commit": "f1ae9dbf964ef143fa812b8f6ce311742cba71f8",
   "timestamp": "2026-09-03T00:00:00Z",
   "metrics": {
-    "statements": { "covered": 4, "total": 1053, "percent": 0.3798670465337132 },
+    "statements": {
+      "covered": 4,
+      "total": 1053,
+      "percent": 0.3798670465337132
+    },
     "branches": { "covered": 1, "total": 18, "percent": 5.555555555555555 },
     "functions": { "covered": 0, "total": 17, "percent": 0 },
     "lines": { "covered": 4, "total": 1053, "percent": 0.3798670465337132 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lint:check": "eslint src --ext .ts --max-warnings 0",
     "test": "vitest run",
     "test:watch": "vitest watch",
-    "test:coverage": "vitest run --coverage.enabled --coverage.provider=v8 --coverage.reporter=text --coverage.reporter=json-summary --coverage.reporter=lcov --coverage.reporter=cobertura",
+    "test:coverage": "vitest run --coverage.enabled --coverage.provider=v8 --coverage.reporter=text --coverage.reporter=json --coverage.reporter=json-summary --coverage.reporter=lcov --coverage.reporter=cobertura",
     "spell:check": "cspell \"{README.md,CODE_OF_CONDUCT.md,CONTRIBUTING.md,.github/*.md,src/**/*.ts}\"",
     "release": "pnpm build && changeset publish",
     "commit": "pnpm changeset",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lint:check": "eslint src --ext .ts --max-warnings 0",
     "test": "vitest run",
     "test:watch": "vitest watch",
-    "test:coverage": "vitest run --coverage.enabled --coverage.provider=v8 --coverage.reporter=text --coverage.reporter=json --coverage.reporter=json-summary --coverage.reporter=lcov --coverage.reporter=cobertura",
+    "test:coverage": "vitest run --coverage.enabled --coverage.all --coverage.include=src/**/*.ts --coverage.provider=v8 --coverage.reporter=text --coverage.reporter=json --coverage.reporter=json-summary --coverage.reporter=lcov --coverage.reporter=cobertura",
     "spell:check": "cspell \"{README.md,CODE_OF_CONDUCT.md,CONTRIBUTING.md,.github/*.md,src/**/*.ts}\"",
     "release": "pnpm build && changeset publish",
     "commit": "pnpm changeset",


### PR DESCRIPTION
OPS-182 only: pin required and release reusable workflow calls to central release `b0bd33051b7b5b8ebe0a8f5a1c588ea0d466ed2d`.

This clean replacement is based on current `main` and excludes OPS-183 permission changes and unrelated work.