### PR TITLE
OPS-184: adopt security gates

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -20,6 +20,17 @@ jobs:
     permissions:
       contents: read
     uses: otedesco/gh-action-templates/.github/workflows/lint-and-test.yml@528e0d92182a23a12f9d6d4dae67c4b0e98fcffb # OPS-183 least-privilege workflows
+
+  security:
+    name: Security / aggregate
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: otedesco/gh-action-templates/.github/workflows/security.yml@32dcc51235dc1332104aab1ceb461e495ba8761f # OPS-184 security gates
+    with:
+      registry-auth-required: true
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     with:
       registry-auth-required: true
     secrets:


### PR DESCRIPTION
## Summary
- add the immutable central OPS-184 security workflow caller
- keep repository workflow permissions read-only
- preserve NPM_TOKEN mapping only for private dependency repositories

## Validation
- central security workflow contract and permission audits pass at `32dcc51235dc1332104aab1ceb461e495ba8761f`
- repository branch commit: `68e3e60`

This PR is part of the OPS-184 eight-repository adoption set.