### PR TITLE
test: verify OPS-186 live ruleset enforcement

### DIFF
--- a/.github/OPS-186-live-ruleset-verification.md
+++ b/.github/OPS-186-live-ruleset-verification.md
@@ -1,0 +1,3 @@
+# OPS-186 live ruleset verification fixture
+
+This harmless file exists only on the controlled verification branch. It proves that an ordinary pull request must satisfy the active review, CODEOWNERS, conversation-resolution, strict-check, and protected-history rules before merge.


### PR DESCRIPTION
Controlled OPS-186 verification PR. This harmless documentation-only change is used to prove that passing CI is insufficient without the required CODEOWNER approval, resolved conversations, and a current base. Do not merge until the verification evidence has been captured.